### PR TITLE
[bug] fix floating point param source generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ riderModule.iml
 .vs
 /Benchmarks/**/*.log
 /Benchmarks/**/*.csv
+.idea/
+Validly.sln.DotSettings.user

--- a/Examples/Validly.Extensions.AspNetCore.Example/Users/Dtos/CreateUserRequest.cs
+++ b/Examples/Validly.Extensions.AspNetCore.Example/Users/Dtos/CreateUserRequest.cs
@@ -16,7 +16,7 @@ public partial class CreateUserRequest
 	[EmailAddress]
 	public required string Email { get; init; }
 
-	[Between(18, 120)]
+	[Between(18, 120.1)]
 	public required int Age { get; init; }
 
 	[NotEmpty]

--- a/Validly.SourceGenerator/Validly.SourceGenerator/Utils/Mapping/SymbolMapper.cs
+++ b/Validly.SourceGenerator/Validly.SourceGenerator/Utils/Mapping/SymbolMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.CodeAnalysis;
 
 namespace Validly.SourceGenerator.Utils.Mapping;
@@ -104,6 +105,7 @@ internal static class SymbolMapper
 				string s => $"\"{s}\"",
 				char c => $"'{c}'",
 				bool b => b.ToString().ToLowerInvariant(),
+				double d => d.ToString(new NumberFormatInfo { NumberDecimalSeparator = "." }),
 				_ => constant.Value?.ToString() ?? "null",
 			},
 			_ => constant.Value?.ToString() ?? "null",

--- a/Validly.SourceGenerator/Validly.SourceGenerator/Utils/Mapping/SymbolMapper.cs
+++ b/Validly.SourceGenerator/Validly.SourceGenerator/Utils/Mapping/SymbolMapper.cs
@@ -106,6 +106,7 @@ internal static class SymbolMapper
 				char c => $"'{c}'",
 				bool b => b.ToString().ToLowerInvariant(),
 				double d => d.ToString(new NumberFormatInfo { NumberDecimalSeparator = "." }),
+				float f => f.ToString(new NumberFormatInfo { NumberDecimalSeparator = "." }),
 				_ => constant.Value?.ToString() ?? "null",
 			},
 			_ => constant.Value?.ToString() ?? "null",

--- a/Validly.SourceGenerator/Validly.SourceGenerator/Validly.SourceGenerator.csproj
+++ b/Validly.SourceGenerator/Validly.SourceGenerator/Validly.SourceGenerator.csproj
@@ -13,7 +13,7 @@
 		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
 
         <PackageId>Validly.SourceGenerator</PackageId>
-		<Version>1.1.4</Version>
+		<Version>1.1.5</Version>
 		<Description>Source Generator for Validly validation library</Description>
 		<PackageTags>validly valid validator validation annotations attributes source-generator</PackageTags>
 		<IsPackable>true</IsPackable>


### PR DESCRIPTION
Attribute `[Between(18, 120.1)]` translated to `new global::Validly.Extensions.Validators.Numbers.BetweenAttribute(18, 120,1)`

Now it is `new global::Validly.Extensions.Validators.Numbers.BetweenAttribute(18, 120.1)`

System Info:
- macOS Ventura 13.7.2
- Apple M1 Pro
- .NET SDK 9.0.200
- Validly.SourceGenerator 1.1.4