### PR TITLE
[bug] Enable NativeAOT support by using source generation JSON serialization for ValidationMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ riderModule.iml
 .vs
 /Benchmarks/**/*.log
 /Benchmarks/**/*.csv
+.idea/
+Validly.sln.DotSettings.user

--- a/Validly.Tests/ValidationMessageTests.cs
+++ b/Validly.Tests/ValidationMessageTests.cs
@@ -1,0 +1,35 @@
+namespace Validly.Tests;
+
+public class ValidationMessageTests
+{
+	[Theory]
+	[MemberData(nameof(ArgsJsonData))]
+	public void ArgsJson_Test(ValidationMessage message, string expected)
+	{
+		Assert.Equal(message.ArgsJson, expected);
+	}
+
+	public static TheoryData<ValidationMessage, string> ArgsJsonData = new()
+	{
+		{
+			new ValidationMessage("Test error {0} {1}", "message.key", null, null),
+			"null, null"
+		},
+		{
+			new ValidationMessage("Test error {0}", "message.key", 1.1m),
+			"1.1"
+		},
+		{
+			new ValidationMessage("Test error {0}", "message.key", 1),
+			"1"
+		},
+		{
+			new ValidationMessage("Test error {0}", "message.key", "string"),
+			"\"string\""
+		},
+		{
+			new ValidationMessage("Test error {0} {1} {2} {3}", "message.key", 1.1m, 1, "string", null),
+			"1.1, 1, \"string\", null"
+		},
+	};
+}

--- a/Validly/ValidationMessage.cs
+++ b/Validly/ValidationMessage.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Validly;
 
@@ -9,12 +11,20 @@ namespace Validly;
 /// <param name="Message">Translated message, or default message (e.g., in English)</param>
 /// <param name="ResourceKey">Resource key for localization, which may contain placeholders (e.g., {0}) for passed arguments.</param>
 /// <param name="Args">Arguments</param>
-public record ValidationMessage(
+public partial record ValidationMessage(
 	[StringSyntax(StringSyntaxAttribute.CompositeFormat)] string Message,
 	string ResourceKey,
 	params object?[] Args
 )
 {
+	private static readonly JsonSerializerOptions ArgumentSerializerOptions = new()
+	{
+		TypeInfoResolverChain =
+		{
+			ArgumentJsonContext.Default
+		}
+	};
+
 	/// <summary>
 	/// Empty validation message
 	/// </summary>
@@ -27,5 +37,12 @@ public record ValidationMessage(
 	/// Prepared to be used within array brackets like: $"[{ArgsJson}]"
 	/// </remarks>
 	public string ArgsJson { get; } =
-		string.Join(", ", Args.Select(static x => JsonValue.Create(x)?.ToJsonString() ?? "null"));
+		string.Join(", ", Args.Select(static x => JsonValue.Create(x)?.ToJsonString(ArgumentSerializerOptions) ?? "null"));
+
+	[JsonSerializable(typeof(object))]
+	[JsonSerializable(typeof(decimal))]
+	[JsonSerializable(typeof(int))]
+	[JsonSerializable(typeof(string))]
+	[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
+	private partial class ArgumentJsonContext : JsonSerializerContext;
 }

--- a/Validly/ValidationMessage.cs
+++ b/Validly/ValidationMessage.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Validly;
@@ -37,7 +36,7 @@ public partial record ValidationMessage(
 	/// Prepared to be used within array brackets like: $"[{ArgsJson}]"
 	/// </remarks>
 	public string ArgsJson { get; } =
-		string.Join(", ", Args.Select(static x => JsonValue.Create(x)?.ToJsonString(ArgumentSerializerOptions) ?? "null"));
+		string.Join(", ", Args.Select(static x => JsonSerializer.Serialize(x, ArgumentSerializerOptions)));
 
 	[JsonSerializable(typeof(object))]
 	[JsonSerializable(typeof(decimal))]

--- a/Validly/Validly.csproj
+++ b/Validly/Validly.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>Validly</PackageId>
-		<Version>1.1.3</Version>
+		<Version>1.1.4</Version>
 		<Description>Powerful, efficient, and highly customizable validation library for .NET, leveraging the capabilities of C# Source Generators to provide compile-time validation logic generation.</Description>
 		<PackageTags>validly valid validator validation annotations attributes source-generator</PackageTags>
 		<IsPackable>true</IsPackable>

--- a/Validly/Validly.csproj
+++ b/Validly/Validly.csproj
@@ -10,6 +10,10 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10"/>


### PR DESCRIPTION
System Info:
- macOS Ventura 13.7.2
- Apple M1 Pro
- .NET SDK 9.0.200
- Validly 1.1.3

If i use Validly package in NativeAOT ASP Net Core WebApi it ultimately fails while constructing ValidationMessage instances:
```
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.TypeInitializationException: The type initializer for 'SourceGenBenefit.After.Create.<CreateTestEntity_Validator_g>F5F9543001A26730BE005DA2785D3B74A7BB99337B69C23C9FF45D53D895D67F9__CreateTestEntityRules' threw an exception.
       ---> System.NotSupportedException: JsonTypeInfo metadata for type 'System.Decimal' was not provided by TypeInfoResolver of type 'System.Text.Json.Serialization.Metadata.EmptyJsonTypeInfoResolver'. If using source generation, ensure that all root types passed to the serializer have been annotated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.
         at System.Text.Json.ThrowHelper.ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver resolver)
         at System.Text.Json.JsonSerializerOptions.GetTypeInfoInternal(Type type, Boolean ensureConfigured, Nullable`1 ensureNotNull, Boolean resolveIfMutable, Boolean fallBackToNearestAncestorType)
         at System.Text.Json.JsonSerializerOptions.GetTypeInfoForRootType(Type type, Boolean fallBackToNearestAncestorType)
         at System.Text.Json.JsonSerializerOptions.TryGetPolymorphicTypeInfoForRootType(Object rootValue, JsonTypeInfo& polymorphicTypeInfo)
         at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Serialize(Utf8JsonWriter writer, T& rootValue, Object rootValueBoxed)
         at System.Text.Json.Nodes.JsonValueCustomized`1.WriteTo(Utf8JsonWriter writer, JsonSerializerOptions options)
         at System.Text.Json.Nodes.JsonNode.ToJsonString(JsonSerializerOptions options)
         at Validly.ValidationMessage.<>c.<.ctor>b__0_0(Object x)
         at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()
         at System.String.Join(String separator, IEnumerable`1 values)
         at Validly.ValidationMessage..ctor(String Message, String ResourceKey, Object[] Args)
         at Validly.Extensions.Validators.Numbers.BetweenAttribute.CreateMessage()
         at Validly.Extensions.Validators.Numbers.BetweenAttribute..ctor(Int32 min, Int32 max)
         at SourceGenBenefit.After.Create.<CreateTestEntity_Validator_g>F5F9543001A26730BE005DA2785D3B74A7BB99337B69C23C9FF45D53D895D67F9__CreateTestEntityRules..cctor() in /Users/stepanminin/RiderProjects/SourceGenBenefit/SourceGenBenefit.After/obj/Release/net9.0/Validly.SourceGenerator/Validly.SourceGenerator.ValidatableSourceGenerator/CreateTestEntity.Validator.g.cs:line 93
         --- End of inner exception stack trace ---
         at SourceGenBenefit.After.Create.CreateTestEntity.global::Validly.Validators.IInternalValidationInvoker.ValidateAsync(ValidationContext context, IServiceProvider serviceProvider) in /Users/stepanminin/RiderProjects/SourceGenBenefit/SourceGenBenefit.After/obj/Release/net9.0/Validly.SourceGenerator/Validly.SourceGenerator.ValidatableSourceGenerator/CreateTestEntity.Validator.g.cs:line 29
         at SourceGenBenefit.After.Create.CreateTestEntity.ValidateAsync() in /Users/stepanminin/RiderProjects/SourceGenBenefit/SourceGenBenefit.After/obj/Release/net9.0/Validly.SourceGenerator/Validly.SourceGenerator.ValidatableSourceGenerator/CreateTestEntity.Validator.g.cs:line 64
         at SourceGenBenefit.After.Create.CreateTestEntityCommandHandler.Handle(CreateTestEntityCommand request, CancellationToken ct) in /Users/stepanminin/RiderProjects/SourceGenBenefit/SourceGenBenefit.After/Create/CreateTestEntityCommand.cs:line 19
         at Microsoft.AspNetCore.Http.Generated.<GeneratedRouteBuilderExtensions_g>F9A166B871EFB5674D33D4059C03D582B81CEB6BDB3A9D8DB49CD497DFBC1AA94__GeneratedRouteBuilderExtensionsCore.<>c__DisplayClass5_0.<<MapPost1>g__RequestHandler|5>d.MoveNext() in /Users/stepanminin/RiderProjects/SourceGenBenefit/SourceGenBenefit.After.Api/obj/Release/net9.0/Microsoft.AspNetCore.Http.RequestDelegateGenerator/Microsoft.AspNetCore.Http.RequestDelegateGenerator.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs:line 278
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```

`[JsonSerializable]` type list was chosen according to current `ValidationMessage` ctor usage