### PR TITLE
fix IL trimming warnings

### DIFF
--- a/Validly/ValidationMessage.cs
+++ b/Validly/ValidationMessage.cs
@@ -16,9 +16,6 @@ public partial record ValidationMessage(
 	params object?[] Args
 )
 {
-	private static readonly JsonSerializerOptions ArgumentSerializerOptions =
-		new() { TypeInfoResolverChain = { ArgumentJsonContext.Default } };
-
 	/// <summary>
 	/// Empty validation message
 	/// </summary>
@@ -31,7 +28,9 @@ public partial record ValidationMessage(
 	/// Prepared to be used within array brackets like: $"[{ArgsJson}]"
 	/// </remarks>
 	public string ArgsJson { get; } =
-		string.Join(", ", Args.Select(static x => JsonSerializer.Serialize(x, ArgumentSerializerOptions)));
+		string.Join(", ", Args.Select(static x => x is null
+			? "null"
+			: JsonSerializer.Serialize(x, ArgumentJsonContext.Default.Object)));
 
 	[JsonSerializable(typeof(object))]
 	[JsonSerializable(typeof(string))]


### PR DESCRIPTION
Using `JsonSerializer.Serialize{TValue}(TValue, JsonTypeInfo{TValue})` overload to avoid IL warnings

Info:
- Validly 1.1.5

Still have trouble publishing AOT:
```
    ILC : Trim analysis warning IL2026: Validly.ValidationMessage.<>c.<.ctor>b__0_0(Object): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
    ILC : AOT analysis warning IL3050: Validly.ValidationMessage.<>c.<.ctor>b__0_0(Object): Using member 'System.Text.Json.JsonSerializer.Serialize<Object>(Object,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
```